### PR TITLE
Fix dataset map imports

### DIFF
--- a/apps/backend/src/jobs/classification/classifyLeads.job.ts
+++ b/apps/backend/src/jobs/classification/classifyLeads.job.ts
@@ -3,11 +3,13 @@
 import fs from 'fs';
 import path from 'path';
 import { parse } from 'csv-parse/sync';
-import { prisma } from '../../database/prisma';
-import datasets from '../../datasets.json';
-import camposMap from '../../dataset_campos_map.json';
+import { prisma } from '../../database/prismaClient';
+import datasets from '../../../data/datasets.json';
+import camposMapRaw from '../../../data/dataset_campos_map.json';
 
-const downloadsDir = path.resolve(__dirname, '../../downloads');
+const camposMap = camposMapRaw as Record<string, Record<string, string>>;
+
+const downloadsDir = path.resolve(__dirname, '../../../data/downloads');
 
 async function importarEnergia() {
   let total = 0;

--- a/apps/backend/src/jobs/quality/importQuality.job.ts
+++ b/apps/backend/src/jobs/quality/importQuality.job.ts
@@ -3,11 +3,13 @@
 import fs from 'fs';
 import path from 'path';
 import { parse } from 'csv-parse/sync';
-import { prisma } from '../../database/prisma';
-import datasets from '../../datasets.json';
-import camposMap from '../../dataset_campos_map.json';
+import { prisma } from '../../database/prismaClient';
+import datasets from '../../../data/datasets.json';
+import camposMapRaw from '../../../data/dataset_campos_map.json';
 
-const downloadsDir = path.resolve(__dirname, '../../downloads');
+const camposMap = camposMapRaw as Record<string, Record<string, string>>;
+
+const downloadsDir = path.resolve(__dirname, '../../../data/downloads');
 
 async function importarQualidade() {
   let total = 0;

--- a/apps/backend/src/jobs/utils/generateFieldMap.job.ts
+++ b/apps/backend/src/jobs/utils/generateFieldMap.job.ts
@@ -2,8 +2,8 @@
 import fs from 'fs';
 import path from 'path';
 
-const datasetsPath = path.resolve(__dirname, '../../datasets.json');
-const outputPath = path.resolve(__dirname, '../../dataset_campos_map.json');
+const datasetsPath = path.resolve(__dirname, '../../../data/datasets.json');
+const outputPath = path.resolve(__dirname, '../../../data/dataset_campos_map.json');
 
 // Heurística de mapeamento por palavras-chave comuns
 const heuristicas = {

--- a/apps/backend/src/jobs/utils/scanBDGD.job.ts
+++ b/apps/backend/src/jobs/utils/scanBDGD.job.ts
@@ -24,8 +24,8 @@ const datasets: { nome: string; url: string; origem: string }[] = [
   },
 ];
 
-const downloadsDir = path.resolve(__dirname, '../downloads');
-const datasetsPath = path.resolve(__dirname, '../datasets.json');
+const downloadsDir = path.resolve(__dirname, '../../../data/downloads');
+const datasetsPath = path.resolve(__dirname, '../../../data/datasets.json');
 
 async function baixarArquivo(url: string, nome: string): Promise<string> {
   const filePath = path.join(downloadsDir, nome);
@@ -46,7 +46,7 @@ async function extrairZip(zipPath: string): Promise<string> {
   await new Promise((res, rej) => {
     firstCsv.stream()
       .pipe(fs.createWriteStream(extractedPath))
-      .on('finish', res)
+      .on('finish', () => res(extractedPath))
       .on('error', rej);
   });
   return extractedPath;


### PR DESCRIPTION
## Summary
- fix dataset map typing for classify and quality jobs
- ensure extracted zip resolution is returned in BDGD scan util

## Testing
- `npm test` *(fails: no test specified)*
- `npx jest` *(fails: test suites failed)*
- `npx tsc --noEmit` *(fails: PrismaClient not generated)*

------
https://chatgpt.com/codex/tasks/task_e_6841ac4f09008331b08e110cbcbf3ba1